### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
       codecov_token:
         required: true
 
+permissions:
+  contents: read
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/atraplet/clarabel4j/security/code-scanning/2](https://github.com/atraplet/clarabel4j/security/code-scanning/2)

The recommended way to fix this problem is to add a `permissions` block at the root of the workflow, before `jobs:`. This will apply the permissions to all jobs in the workflow unless overridden. To follow the principle of least privilege, only the permissions needed to make the workflow function should be granted; a good minimal starting point is `contents: read`. This allows all standard actions like code checkout and reading files, but denies any write access (e.g., pushing commits, modifying PRs). The block should be placed after the `on:` block and before `jobs:` in the workflow file. No additional imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
