### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 
 on:
   push:
@@ -14,6 +16,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [ build ]
+    permissions:
+      contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/detect-jdk


### PR DESCRIPTION
Potential fix for [https://github.com/atraplet/clarabel4j/security/code-scanning/3](https://github.com/atraplet/clarabel4j/security/code-scanning/3)

The fix for this issue is to add an explicit `permissions` block to the workflow. The block should be added at the root level of the YAML file (just after `name: Release` or `on:` block) to apply to all jobs unless overridden by job-level permissions. The permissions should be minimized: restrict to `contents: read` unless the workflow or individual jobs require greater permissions. In this case, the `release` job uses the `softprops/action-gh-release` action to create a release, which needs `contents: write` and `packages: write` permissions. If only "read" is set, release creation will fail. Accordingly, set appropriate permissions at the root or per-job. 

For general safety and clarity, set at the workflow root:
```yaml
permissions:
  contents: write
  packages: write
```
If you prefer to scope the elevated permissions only to the release job and default most jobs to minimal, add this at the root:
```yaml
permissions:
  contents: read
```
and override for the `release` job:
```yaml
    permissions:
      contents: write
      packages: write
```

This fix will be added within `.github/workflows/release.yml`, after the `name:` or `on:` block as appropriate.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
